### PR TITLE
feat(sidekiq): add a Sidekiq Server middleware for sampling

### DIFF
--- a/lib/scout_apm/sampling/sidekiq/server_middleware.rb
+++ b/lib/scout_apm/sampling/sidekiq/server_middleware.rb
@@ -1,0 +1,20 @@
+module ScoutApm
+  module Sampling
+    module Sidekiq
+      include Callbacks
+
+      class ServerMiddleware
+        # @param [Object] worker the worker instance
+        # @param [Hash] job the full job payload
+        #   * @see https://github.com/mperham/sidekiq/wiki/Job-Format
+        # @param [String] queue the name of the queue the job was pulled from
+        # @yield the next middleware in the chain or worker `perform` method
+        # @return [Void]
+        def call(worker, job, queue)
+          sample_workers_for_scout
+          yield
+        end
+      end
+    end
+  end
+end

--- a/lib/scout_apm/sampling/version.rb
+++ b/lib/scout_apm/sampling/version.rb
@@ -1,5 +1,5 @@
 module ScoutApm
   module Sampling
-    VERSION = "3.0.0".freeze
+    VERSION = "3.0.1".freeze
   end
 end


### PR DESCRIPTION
Turns out, we can't use the `before_perform` hook, as it does not exist in `Sidekiq`.

This PR introduces a Server Middleware for sampling workers, which will need to be chained in the app configuration.